### PR TITLE
Fix Toast Rabbit Head not always dropping when supposed to

### DIFF
--- a/kilocraft/data/minecraft/loot_tables/entities/rabbit.json
+++ b/kilocraft/data/minecraft/loot_tables/entities/rabbit.json
@@ -105,14 +105,14 @@
               "functions": [
                 {
                   "function": "set_nbt",
-                  "tag": "{SkullOwner:{Id:[I;0,0,0,0],Name:\"Brown Rabbit\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvN2QxMTY5YjI2OTRhNmFiYTgyNjM2MDk5MjM2NWJjZGE1YTEwYzg5YTNhYTJiNDhjNDM4NTMxZGQ4Njg1YzNhNyJ9fX0=\"}]}}}"
+                  "tag": "{SkullOwner:{Id:[I;0,0,0,0],Name:\"Toast\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMzJmYzNiNzQ2NjY1NDVmMmQ0MWJjMmI1MzQwZTFkZjY5ZGQyNWUyYTdlMmIzNGVmZDFhOTUzMTFhN2Q2YyJ9fX0=\"}]}}}"
                 }
               ],
               "conditions": [
                 {
                   "condition": "entity_properties",
                   "predicate": {
-                    "nbt": "{RabbitType:0}"
+                    "nbt": "{CustomName:'{\"text\":\"Toast\"}'}"
                   },
                   "entity": "this"
                 }
@@ -162,14 +162,14 @@
               "functions": [
                 {
                   "function": "set_nbt",
-                  "tag": "{SkullOwner:{Id:[I;0,0,0,0],Name:\"Toast\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMzJmYzNiNzQ2NjY1NDVmMmQ0MWJjMmI1MzQwZTFkZjY5ZGQyNWUyYTdlMmIzNGVmZDFhOTUzMTFhN2Q2YyJ9fX0=\"}]}}}"
+                  "tag": "{SkullOwner:{Id:[I;0,0,0,0],Name:\"Brown Rabbit\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvN2QxMTY5YjI2OTRhNmFiYTgyNjM2MDk5MjM2NWJjZGE1YTEwYzg5YTNhYTJiNDhjNDM4NTMxZGQ4Njg1YzNhNyJ9fX0=\"}]}}}"
                 }
               ],
               "conditions": [
                 {
                   "condition": "entity_properties",
                   "predicate": {
-                    "nbt": "{CustomName:'{\"text\":\"Toast\"}'}"
+                    "nbt": "{RabbitType:0}"
                   },
                   "entity": "this"
                 }


### PR DESCRIPTION
The Toast Rabbit head is below Brown, Salt & Pepper and Black Rabbit heads, meaning that any Toast Rabbit that has a base of Brown, Black or Salt&Pepper will drop that head, instead of Toast