### PR TITLE
Dragon egg drops

### DIFF
--- a/kilocraft/data/kilocraft/functions/util/wilderness.mcfunction
+++ b/kilocraft/data/kilocraft/functions/util/wilderness.mcfunction
@@ -1,3 +1,3 @@
 effect give @s minecraft:blindness 2 250 true
 execute in kilocraft:mighty_highlands run tp @s 46.5 65.00 3.5 270 -3.75
-rtp perform minecraft:overworld
+sudo as @s rtp perform minecraft:overworld

--- a/kilocraft/data/minecraft/loot_tables/entities/ender_dragon.json
+++ b/kilocraft/data/minecraft/loot_tables/entities/ender_dragon.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:entity",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:dragon_egg"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:random_chance",
+          "chance": 0.2
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
When the ender dragon is killed, it has a 20% chance to drop an ender dragon egg at it's death location.